### PR TITLE
Allow params to be modified and written to backend (shell)

### DIFF
--- a/client/src/pages/Params/Param/Active.js
+++ b/client/src/pages/Params/Param/Active.js
@@ -7,13 +7,15 @@ import Content from "./Content"
 import Value from "./Value"
 import Submit from "./Submit"
 
-const Active = ({ data, hook, ...props }) => {
-	const [active, setActive] = hook
+import { useParameters } from "../../Params"
+
+const Active = ({ data, index, setActiveIndex, setModifiedIndexes }) => {
 	const [value, setValue] = useState(data.value)
-	const toggle = () => setActive(!active)
+	const deactivate = () => setActiveIndex(-1)
+	const params = useParameters()
 
 	return (
-		<form {...props} onSubmit={e => handleSubmit(e, toggle, value)}>
+		<form onSubmit={e => handleSubmit(e, deactivate)}>
 			<Row style={{ maxHeight: "7rem" }} columns="min-content auto 6rem">
 				<div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
 					<Row height="2rem" columns="14rem 6rem">
@@ -30,28 +32,37 @@ const Active = ({ data, hook, ...props }) => {
 				<Column style={{ display: "flex", height: "100%", overflow: "scroll" }}>
 					<Content padded children={data.description} style={{ overflow: "scroll" }} />
 				</Column>
-				<Column>
-					<Submit type="accept" />
+				<aside
+					style={{
+						display: "flex",
+						flexDirection: "column",
+						rowGap: "1rem",
+						height: "100%",
+					}}
+				>
+					<Submit
+						type="accept"
+						callback={() => {
+							params[index] = {
+								...data,
+								value,
+							}
+							setModifiedIndexes(prev => {
+								if (!prev.includes(index)) return [...prev, index]
+								else return prev
+							})
+						}}
+					/>
 					<Submit type="decline" />
-				</Column>
+				</aside>
 			</Row>
 		</form>
 	)
 }
 
-function handleSubmit(e, toggle, value) {
+function handleSubmit(e, deactivate) {
 	e.preventDefault()
-
-	const action = e.nativeEvent.submitter.id
-	if (action === "accept") {
-		// TODO: apply changes, send over to left hand side
-		console.log(value)
-		toggle()
-	}
-
-	if (action === "decline") {
-		toggle()
-	}
+	deactivate()
 }
 
 export default Active

--- a/client/src/pages/Params/Param/Normal.js
+++ b/client/src/pages/Params/Param/Normal.js
@@ -3,26 +3,37 @@ import styled from "styled-components"
 
 import { Row, Column } from "components/Containers"
 import { Button } from "components/UIElements"
-import { dark } from "theme/Colors"
+import { dark, blue } from "theme/Colors"
 
 import Content from "./Content"
 import Value from "./Value"
+import Submit from "./Submit"
 
-const Normal = ({ data, hook, ...props }) => {
-	const [active, setActive] = hook
-
+const Normal = ({ data, index, setActiveIndex, setModifiedIndexes, modified = false }) => {
 	return (
-		<Row {...props} height="2rem" columns="min-content auto 6rem">
+		<Row height="2rem" columns={`min-content auto ${modified ? "3rem" : "6rem"}`}>
 			<Column height="2rem" style={{ overflow: "hidden" }}>
 				<Row columns="14rem 6rem">
 					<Content padded children={data.name} />
-					<Value hook={[data.value, null]} />
+					<Value
+						style={{ color: modified ? blue : "inherit" }}
+						hook={[data.value, null]}
+					/>
 				</Row>
 			</Column>
 			<Column height="2rem">
 				<Description description={data.description.replace(/\s/g, "\u00A0")} />
 			</Column>
-			<Button onClick={() => setActive(!active)}>Modify</Button>
+			{modified ? (
+				<Submit
+					type="decline"
+					callback={() => setModifiedIndexes(prev => prev.filter(i => i !== index))}
+				/>
+			) : (
+				<Button careful onClick={() => setActiveIndex(index)}>
+					Modify
+				</Button>
+			)}
 		</Row>
 	)
 }

--- a/client/src/pages/Params/Param/Submit.js
+++ b/client/src/pages/Params/Param/Submit.js
@@ -12,6 +12,7 @@ const Submit = ({ type, callback }) => (
 			border: "none",
 			borderRadius: "unset",
 			outline: "none",
+      flexShrink: "1"
 		}}
 	></Checkbox>
 )

--- a/client/src/pages/Params/Param/Value.js
+++ b/client/src/pages/Params/Param/Value.js
@@ -2,7 +2,7 @@ import React from "react"
 
 import { dark } from "theme/Colors"
 
-const Value = ({ hook, editable }) => {
+const Value = ({ hook, editable, style }) => {
 	const [value, setValue] = hook
 
 	return (
@@ -12,6 +12,7 @@ const Value = ({ hook, editable }) => {
 			value={value}
 			onChange={e => setValue(e.target.value)}
 			style={{
+				...style,
 				background: dark,
 				border: "none",
 				outline: "none",

--- a/client/src/pages/Params/Param/index.js
+++ b/client/src/pages/Params/Param/index.js
@@ -1,15 +1,13 @@
-import React, { useState } from "react"
+import React from "react"
 
 import Active from "./Active"
 import Normal from "./Normal"
 
-const Param = ({ data, ...props }) => {
-	const [active, setActive] = useState(false)
-
+const Param = ({ data, active, index, setActiveIndex, setModifiedIndexes, ...props }) => {
 	// prettier-ignore
 	return active
-	    ? <Active {...props} data={data} hook={[active, setActive]} />
-	    : <Normal {...props} data={data} hook={[active, setActive]} />
+	    ? <Active {...props} data={data} index={index} setActiveIndex={setActiveIndex} setModifiedIndexes={setModifiedIndexes} />
+	    : <Normal {...props} data={data} index={index} setActiveIndex={setActiveIndex} setModifiedIndexes={setModifiedIndexes} />
 }
 
 export default Param


### PR DESCRIPTION
Made a lot of progress on the params page.

## What *was* done:
- Params list is performant and offers the ability to change values (didn't keep track of it).
- Regular expressions can be used to search through params by both name and description.
- General layout, such as buttons and columns.

## What this PR does:
- Params whose values have been modified and accepted are sent over to a list on the left-hand side of the page.  From there, they can be removed from the list.  
- Clicking on the `Write` button at the top-left prints all of the modified values in the list, as well as the rest of their param data, to the console.

## What still needs to be done:
- Implement `Read` button functionality.
- Implement `Save` button functionality.
- Implement `Load` button functionality.
- connect all of the buttons to the backend (which should then take the proper action with the data).
- Double check all of the params and descriptions and find all of their default values.