### PR TITLE
Add automations for Black refactoring

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,12 +1,13 @@
-name: Lint
+name: Black
 
 on: [push, pull_request]
 
 jobs:
-  lint:
+  black:
+    name: Check Python Formatting
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: psf/black@stable
         with:
-          options: "-l 99 --check --diff --color"
+          options: "-l 99 --extend-exclude auvsi_suas --check --diff --color"

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,12 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: psf/black@stable
+        with:
+          options: "-l 99 --check --diff --color"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,3 +6,4 @@ repos:
         args: [-l, '99']
         language_version: python3.10
         verbose: true
+        exclude: .*auvsi_suas.*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 22.6.0
+    hooks:
+      - id: black
+        args: [-l, '99']
+        language_version: python3.10
+        verbose: true

--- a/client/public/assets/change_color.py
+++ b/client/public/assets/change_color.py
@@ -2,6 +2,6 @@ import cv2
 
 img = cv2.imread("icon-fence.png", cv2.IMREAD_UNCHANGED)
 dst = img.copy()
-dst[:,:,0] = img[:,:,2]
-dst[:,:,2] = img[:,:,0]
+dst[:, :, 0] = img[:, :, 2]
+dst[:, :, 2] = img[:, :, 0]
 cv2.imwrite("icon-polygons.png", dst)

--- a/client/public/slippy_map_getter.py
+++ b/client/public/slippy_map_getter.py
@@ -8,6 +8,7 @@ import time
 # top lat: 38.15163
 # bot lat: 38.14177
 
+
 def main():
     lon = -76.428038
     lat = 38.1458611
@@ -31,7 +32,7 @@ def main():
 
     print()
     for i in range(9, 19):
-        zoom_deg = deg_distance * (2**(zoom - i))
+        zoom_deg = deg_distance * (2 ** (zoom - i))
         # assuming in northwest hemisphere
         x1, y1 = convert_to_slippy(lat + deg_distance, lon - deg_distance, i)
         x2, y2 = convert_to_slippy(lat - deg_distance, lon + deg_distance, i)
@@ -42,26 +43,30 @@ def main():
                     if not os.path.exists(f"./map/{i}/{j}"):
                         os.makedirs(f"./map/{i}/{j}")
 
-                    print("Downloading: [x: " + str(j) + ", y: " + str(k) + ", zoom: " + str(i) + "]")
+                    print(
+                        "Downloading: [x: " + str(j) + ", y: " + str(k) + ", zoom: " + str(i) + "]"
+                    )
                     url = f"https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{i}/{k}/{j}.png"
                     r = requests.get(url, allow_redirects=False)
                     file = open(f"./map/{i}/{j}/{k}.png", "wb")
                     file.write(r.content)
                     file.close()
 
-                    time.sleep(1/2000)
+                    time.sleep(1 / 2000)
+
 
 def convert_to_slippy(lat, lon, zoom):
-    x = lon*math.pi/180
-    y = math.log(math.tan(lat*math.pi/180) + 1/math.cos(lat*math.pi/180)) # natural log
+    x = lon * math.pi / 180
+    y = math.log(math.tan(lat * math.pi / 180) + 1 / math.cos(lat * math.pi / 180))  # natural log
 
-    x = (1 + x/math.pi)/2
-    y = (1 - y/math.pi)/2
+    x = (1 + x / math.pi) / 2
+    y = (1 - y / math.pi) / 2
 
     x = int(x * (2**zoom))
     y = int(y * (2**zoom))
 
     return (x, y)
+
 
 if __name__ == "__main__":
     main()

--- a/server/handlers/uav/dummy.py
+++ b/server/handlers/uav/dummy.py
@@ -78,7 +78,9 @@ class DummyUAVHandler:
         self.port = self.config["uav"]["telemetry"]["port"]
         self.serial = self.config["uav"]["telemetry"]["serial"]
         self.update_thread = None
-        self.altitude = self.altitude_global = (
+        self.altitude = (
+            self.altitude_global
+        ) = (
             self.orientation
         ) = (
             self.ground_speed


### PR DESCRIPTION
 - Refactor current backend code with `black`

 - Add `.github/workflows/black.yml` for automatically verifying a proper `black` format

 - Add `.pre-commit-config.yaml` as a git hook configuration file with `pre-commit`, to automatically format all Python files with `black` on commit.
   *Note: This will only be triggered if `pre-commit` is installed and a git hook is created manually using the `pre-commit` configuration. See [the guide](https://pre-commit.com/#3-install-the-git-hook-scripts) for more info.*