### PR TITLE
Params Routes Logging and Plane Loading Notifcation

### DIFF
--- a/client/src/pages/Params/index.js
+++ b/client/src/pages/Params/index.js
@@ -3,13 +3,15 @@ import styled from "styled-components"
 
 import { Row, Column } from "components/Containers"
 import { Button, Box, Label } from "components/UIElements"
-import { darkest, darkdark } from "theme/Colors"
+import { dark, darkest, darkdark } from "theme/Colors"
 import { httpget, httppost } from "../../backend"
+import { useInterval } from "../../util"
 
 import { VariableSizeList } from "react-window"
 import AutoSizer from "react-virtualized-auto-sizer"
 
 import Param from "./Param"
+
 /*
 Current params functionality:
 You can load a param file, and it will load all known params (known params are those in the paramDescriptions dictionary).
@@ -57,6 +59,7 @@ const Params = () => {
 	const [modifiedIndexes, setModifiedIndexes] = useState([])
 	const [parameters, setParameters] = useState(INITIAL_PARAMS)
 	const [parametersSave, setParametersSave] = useState(INITIAL_PARAMS.slice())
+	const [downloaded, setDownloaded] = useState(false)
 
 	const isEnabled = (param) => {
 		if (param.includes("_ENABLE")) {
@@ -138,6 +141,12 @@ const Params = () => {
 	}, [])
 
 	const [activeSize, setActiveSize] = useState(35)
+
+	useInterval(1000, () => {
+		httpget("/uav/params/downloaded", response => {
+			setDownloaded(response.data.result)
+		})
+	})
 
 	return (
 		<ParametersContext.Provider value={[parameters, setParameters]}>
@@ -233,6 +242,17 @@ const Params = () => {
 							)
 						})}
 					</section>
+					<div style={{ margin: "0.5em", padding: "0.5em", background: dark }}>
+						{downloaded ? (
+							<>
+								Viewing parameters from plane (not local file)
+							</>
+						) : (
+							<>
+								Viewing local parameters file
+							</>
+						)}
+					</div>
 				</div>
 				<Column
 					height="100%"

--- a/server/apps/uav.py
+++ b/server/apps/uav.py
@@ -3,6 +3,7 @@ import os.path
 from flask import Blueprint, current_app as app, request, send_file
 import logging
 from utils.errors import InvalidRequestError
+from handlers import DummyUAVHandler
 
 uav = Blueprint("uav", __name__)
 
@@ -249,3 +250,8 @@ def uav_load_params():
     load = app.gs.uav.load_params()
     logger.info("/uav/params/load : Parameters loaded from plane")
     return load
+
+
+@uav_params.route("/downloaded")
+def uav_params_downloaded():
+    return {"result": False if type(app.gs.uav) == DummyUAVHandler else "parameters" in app.gs.uav.vehicle._ready_attrs}

--- a/server/apps/uav.py
+++ b/server/apps/uav.py
@@ -1,11 +1,12 @@
 import os.path
 
 from flask import Blueprint, current_app as app, request, send_file
-
+import logging
 from utils.errors import InvalidRequestError
 
 uav = Blueprint("uav", __name__)
 
+logger: logging.Logger = logging.getLogger('groundstation')
 
 @uav.route("/connect", methods=["POST"])
 def uav_connect():
@@ -207,17 +208,23 @@ uav.register_blueprint(uav_params, url_prefix="/params")
 
 @uav_params.route("/get/<key>")
 def uav_get_param(key):
-    return app.gs.uav.get_param(key)
+    ret = app.gs.uav.get_param(key)
+    logger.info(f"/uav/params/get : Parameter {key} retrieved from local file")
+    return ret
 
 
 @uav_params.route("/getall")
 def uav_get_params():
-    return app.gs.uav.get_params()
+    ret = app.gs.uav.get_params()
+    logger.info("/uav/params/getall : Parameters retrieved from local file")
+    return ret
 
 
 @uav_params.route("/set/<key>/<value>", methods=["POST"])
 def uav_set_param(key, value):
-    return app.gs.uav.set_param(key, value)
+    ret = app.gs.uav.set_param(key, value)
+    logger.info(f"/uav/params/set : Parameter {key} set to {value} in local file")
+    return ret
 
 
 @uav_params.route("/setmultiple", methods=["POST"])
@@ -225,14 +232,20 @@ def uav_set_params():
     f = request.json
     if not all(field in f for field in ["params"]):
         raise InvalidRequestError("Missing required fields in request")
-    return app.gs.uav.set_params(**f.get("params"))  # {"param": "newvalue"}
+    ret = app.gs.uav.set_params(**f.get("params"))  # {"param": "newvalue"}
+    logger.info("/uav/params/setall : Parameters set to local file")
+    return ret
 
 
 @uav_params.route("/save", methods=["POST"])
 def uav_save_params():
-    return app.gs.uav.save_params()
+    save = app.gs.uav.save_params()
+    logger.info("/uav/params/save : Parameters saved to plane")
+    return save
 
 
 @uav_params.route("/load", methods=["POST"])
 def uav_load_params():
-    return app.gs.uav.load_params()
+    load = app.gs.uav.load_params()
+    logger.info("/uav/params/load : Parameters loaded from plane")
+    return load

--- a/server/apps/uav.py
+++ b/server/apps/uav.py
@@ -7,7 +7,8 @@ from handlers import DummyUAVHandler
 
 uav = Blueprint("uav", __name__)
 
-logger: logging.Logger = logging.getLogger('groundstation')
+logger: logging.Logger = logging.getLogger("groundstation")
+
 
 @uav.route("/connect", methods=["POST"])
 def uav_connect():
@@ -254,4 +255,10 @@ def uav_load_params():
 
 @uav_params.route("/downloaded")
 def uav_params_downloaded():
-    return {"result": False if type(app.gs.uav) == DummyUAVHandler else "parameters" in app.gs.uav.vehicle._ready_attrs}
+    return {
+        "result": (
+            False
+            if type(app.gs.uav) == DummyUAVHandler
+            else "parameters" in app.gs.uav.vehicle._ready_attrs
+        )
+    }


### PR DESCRIPTION
When parameter routes such as `/uav/params/load` are called, there is a descriptive log message describing the action. There is now a message on the side of the parameters page saying whether you're viewing a local parameters file or the actual ones from the Pixhawk.